### PR TITLE
fixing district repo to return enrollments to match spec.

### DIFF
--- a/lib/district_repository.rb
+++ b/lib/district_repository.rb
@@ -5,36 +5,33 @@ class DistrictRepository
   attr_reader :districts
 
   def initialize
-    @districts = {}
+    @districts = []
   end
 
   def load_data(args)
     csv_data = CSV.open(args[:enrollment][:kindergarten], headers: true, header_converters: :symbol)
-    district_objects = extract_locations(csv_data)
-    @districts = {:enrollment => {:kindergarten => district_objects}}
+    extract_locations(csv_data)
   end
 
   def extract_locations(csv_data)
     csv_data.map do |row|
       row[:name] = row[:location]
-      District.new(row)
+      if @districts.empty? || find_by_name(row[:name]).nil?
+        @districts << District.new(row) 
+      end
     end
   end
 
   def find_by_name(find_name)
-    districts[:enrollment][:kindergarten].find do |district|
+    districts.find do |district|
       district.name.upcase == find_name.upcase
     end
   end
 
   def find_all_matching(find_name)
-    matched = []
-    districts[:enrollment][:kindergarten].find_all do |district|
-      if district.name.upcase.start_with?(find_name.upcase)
-        matched << district.name
-      end
+    districts.select do |district|
+      district.name.upcase.start_with?(find_name.upcase)
     end
-    matched.uniq
   end
 
 end

--- a/test/district_repository_test.rb
+++ b/test/district_repository_test.rb
@@ -1,5 +1,6 @@
 require_relative 'test_helper'
 require_relative '../lib/district_repository'
+require "pry"
 
 class DistrictRepositoryTest < Minitest::Test
 
@@ -24,7 +25,6 @@ class DistrictRepositoryTest < Minitest::Test
         }
       })
     searched_for = d.find_all_matching("WIL")
-
     assert_equal 1, searched_for.length
 
     not_matched = d.find_all_matching("ASDF")


### PR DESCRIPTION
See changes to "extract locations method". This creates an object ONLY of it doesn't exist or if the value is empty. So it starts as empty and then adds 1. 